### PR TITLE
Backboard to .NET Standard 2.0

### DIFF
--- a/NativeMessaging/Client.cs
+++ b/NativeMessaging/Client.cs
@@ -9,8 +9,8 @@ namespace NativeMessaging
     public class Client : IDisposable
     {
         private Process prog;
-        private AsyncLock ReadLock = new();
-        private AsyncLock WriteLock = new();
+        private AsyncLock ReadLock = new AsyncLock();
+        private AsyncLock WriteLock = new AsyncLock();
 
         public Client(Host host)
         {
@@ -35,26 +35,29 @@ namespace NativeMessaging
 
         public async Task SendMessage(object message)
         {
-            using var l = await ReadLock.LockAsync();
+            using (var l = await ReadLock.LockAsync())
+            {
+                byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(message);
 
-            byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(message);
-            
-            await prog.StandardInput.BaseStream.WriteAsync(BitConverter.GetBytes(bytes.Length));
-            await prog.StandardInput.BaseStream.WriteAsync(bytes);
-            await prog.StandardInput.BaseStream.FlushAsync();
+                var length = BitConverter.GetBytes(bytes.Length);
+                await prog.StandardInput.BaseStream.WriteAsync(length, 0, length.Length);
+                await prog.StandardInput.BaseStream.WriteAsync(bytes, 0, bytes.Length);
+                await prog.StandardInput.BaseStream.FlushAsync();
+            }
         }
 
         public async Task<T> ReadMessage<T>()
         {
-            using (IDisposable l = await ReadLock.LockAsync()) ;
+            using (IDisposable l = await ReadLock.LockAsync())
+            {
+                byte[] bLen = new byte[4];
+                await prog.StandardOutput.BaseStream.ReadAsync(bLen, 0, 4);
+                int len = BitConverter.ToInt32(bLen, 0);
+                byte[] msg = new byte[len];
+                await prog.StandardOutput.BaseStream.ReadAsync(msg, 0, len);
 
-            byte[] bLen = new byte[4];
-            await prog.StandardOutput.BaseStream.ReadAsync(bLen, 0, 4);
-            int len = BitConverter.ToInt32(bLen);
-            byte[] msg = new byte[len];
-            await prog.StandardOutput.BaseStream.ReadAsync(msg, 0, len);
-
-            return JsonSerializer.Deserialize<T>(msg);
+                return JsonSerializer.Deserialize<T>(msg);
+            }
         }
 
         void IDisposable.Dispose()

--- a/NativeMessaging/Host.cs
+++ b/NativeMessaging/Host.cs
@@ -35,7 +35,7 @@ namespace NativeMessaging
         {
             if (Hosts == null)
             {
-                Hosts = new();
+                Hosts = new List<Host>();
 
                 foreach (string loc in RegistryLocations)
                 {

--- a/NativeMessaging/ManifestFile.cs
+++ b/NativeMessaging/ManifestFile.cs
@@ -32,7 +32,12 @@ namespace NativeMessaging
 
         public static async Task<ManifestFile> LoadFile(string path)
         {
-            var data = await File.ReadAllTextAsync(path);
+            string data;
+            using (var streamReader = new StreamReader(path))
+            {
+                await streamReader.ReadToEndAsync();
+                data = File.ReadAllText(path);
+            }
             return JsonSerializer.Deserialize<ManifestFile>(data);
         }
     }

--- a/NativeMessaging/NativeMessaging.csproj
+++ b/NativeMessaging/NativeMessaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description />
     <PackageProjectUrl>https://github.com/TheHllm/NativeMessaging</PackageProjectUrl>
     <RepositoryUrl>https://github.com/TheHllm/NativeMessaging</RepositoryUrl>
@@ -13,11 +13,13 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>NativeMessaging,Chrome</PackageTags>
     <Version>1.0.1</Version>
+  
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Only view changes where needed to make it compatible with .NET Standard 2.0.
I was not really sure if it is allowed to use C# 8.0 for .NET Standard, MS says, that some language features needs support in the runtime libraries which are not part of .NET Standard. Because I was not sure, if the compile would complain for such issues, I decide to downgrade the C# version. So, the one line using was not possible and the new() syntax was not allowed.
File.ReadAllTextAsync was not supported (Only the none async method is part of .NET Standard 2.0), so I rewrote it to use a StreamReader. 